### PR TITLE
Add state_class to support statistics and long-term history

### DIFF
--- a/custom_components/airco2ntrol/sensor.py
+++ b/custom_components/airco2ntrol/sensor.py
@@ -9,7 +9,7 @@ import logging
 import os
 import datetime
 
-from homeassistant.components.sensor import  SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import UnitOfTemperature, CONCENTRATION_PARTS_PER_MILLION, PERCENTAGE
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, CoordinatorEntity
@@ -204,6 +204,7 @@ class AirCO2ntrolSensor(CoordinatorEntity, SensorEntity):
         self._attr_icon = icon
         self._attr_device_class = device_class
         self._attr_unique_id = f"{unique_id}-{sensor_type}"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
         self.sensor_type = sensor_type
 
     @property


### PR DESCRIPTION
This PR adds the `state_class` attribute to all sensor entities, enabling:

- Statistics and long-term history support in Home Assistant
- Use of the built-in statistics graph cards

Currently, the entities created by this integration (CO2, temperature, humidity) do **not** appear in the statistics graph cards. This is because they are missing the required `state_class` attribute, which tells Home Assistant how the sensor data should be stored over time.

By adding `state_class: measurement`, the sensors now:

- Appear as valid sources in statistics-based cards
- Are eligible for long-term storage and aggregation
- Improve overall integration with Home Assistant dashboards